### PR TITLE
fix use of compressed nifti as deformation field

### DIFF
--- a/brainvisa/toolboxes/spm/processes/spm12/util/SPM12composition_generic.py
+++ b/brainvisa/toolboxes/spm/processes/spm12/util/SPM12composition_generic.py
@@ -1,4 +1,7 @@
-import os, numpy
+import numpy
+import os
+import shutil
+from tempfile import mkdtemp
 
 from brainvisa.processes import Application, Signature
 from brainvisa.processes import ReadDiskItem, WriteDiskItem, Choice, Integer
@@ -58,13 +61,13 @@ def deformation_type_choice(num):
 
 def dartel_params(num):
     return {
-        f'flow_field_{num}': ReadDiskItem('4D Volume', getAllFormats(),
+        f'flow_field_{num}': ReadDiskItem('4D Volume', ['NIFTI-1 image', 'SPM image', 'MINC image'],
                                           section=deformations.format(num)),
         f'direction_{num}': Choice(('Forward', [0, 1]), ('Backward', [1, 0]),
                                    section=deformations.format(num)),
         f'time_step_{num}': Choice(*[(2**i, i) for i in range(10)],
                                    section=deformations.format(num)),
-        f'dartel_template_{num}': ReadDiskItem('4D Volume', getAllFormats(),
+        f'dartel_template_{num}': ReadDiskItem('4D Volume', ['NIFTI-1 image', 'SPM image', 'MINC image'],
                                                section=deformations.format(num))
     }
 
@@ -78,7 +81,7 @@ def deformation_params(num):
 
 def identity_image_params(num):
     return {
-        f'base_image_{num}': ReadDiskItem('4D Volume', getAllFormats(),
+        f'base_image_{num}': ReadDiskItem('4D Volume', ['NIFTI-1 image', 'SPM image', 'MINC image'],
                                           section=deformations.format(num))
     }
 
@@ -183,55 +186,71 @@ def update_defo_type(self, num):
 
 def execution(self, context):
 
-    deformations = Deformations()
-    for i in range(1, self.deformation_number + 1):
-        deformation_type = getattr(self, f'deformation_type_{i}')
-        if deformation_type == 'dartel':
-            deformation_element = composition.DartelFlow()
-            deformation_element.flow_field_path = getattr(self, f'flow_field_{i}').fullPath()
-            deformation_element.flow_direction = getattr(self, f'direction_{i}')
-            deformation_element.time_step = getattr(self, f'time_step_{i}')
-            deformation_element.setDartelTemplatePath(getattr(self, f'dartel_template_{i}').fullPath())
-        elif deformation_type == 'deformation':
-            deformation_element = composition.DeformationField()
-            deformation_element.deformation_field_path = getattr(self, f'deformation_field_{i}').fullPath()
-        elif deformation_type == 'identity_image':
-            deformation_element = composition.IdentityFromImage()
-            deformation_element.reference_image_path = getattr(self, f'base_image_{i}').fullPath()
-        elif deformation_type == 'identity_shape':
-            deformation_element = composition.Identity()
-            voxel_size = getattr(self, f'voxel_size_{i}')
-            if voxel_size:
-                deformation_element.voxel_size = voxel_size
-            bounding_box = getattr(self, f'bounding_box_{i}')
-            if bounding_box:
-                deformation_element.bounding_box = numpy.array(bounding_box)
-        elif deformation_type == 'imported_mat':
-            deformation_element = composition.MatFileImported()
-            deformation_element.parameter_file_path = getattr(self, f'param_file_{i}').fullPath()
-            voxel_size = getattr(self, f'voxel_size_{i}')
-            if voxel_size:
-                deformation_element.voxel_size = voxel_size
-            bounding_box = getattr(self, f'bounding_box_{i}')
-            if bounding_box:
-                deformation_element.bounding_box = numpy.array(bounding_box)
+    temp_directory = context.temporary('Directory')
+    try:
+        deformations = Deformations()
+        for i in range(1, self.deformation_number + 1):
+            deformation_type = getattr(self, f'deformation_type_{i}')
+            if deformation_type == 'dartel':
+                deformation_element = composition.DartelFlow()
+                deformation_element.flow_field_path = getattr(self, f'flow_field_{i}').fullPath()
+                deformation_element.flow_direction = getattr(self, f'direction_{i}')
+                deformation_element.time_step = getattr(self, f'time_step_{i}')
+                deformation_element.setDartelTemplatePath(getattr(self, f'dartel_template_{i}').fullPath())
+
+            elif deformation_type == 'deformation':
+                deformation_element = composition.DeformationField()
+                deformation_file = getattr(self, f'deformation_field_{i}').fullPath()
+                if deformation_file.endswith('.gz'):
+                    src_gz = shutil.copy(deformation_file, temp_directory.fullPath())
+                    context.system('gunzip', src_gz)
+                    source = '.'.join(src_gz.split('.')[:-1])
+                else:
+                    source = deformation_file
+                deformation_element.deformation_field_path = source
+                
+            elif deformation_type == 'identity_image':
+                deformation_element = composition.IdentityFromImage()
+                deformation_element.reference_image_path = getattr(self, f'base_image_{i}').fullPath()
+                
+            elif deformation_type == 'identity_shape':
+                deformation_element = composition.Identity()
+                voxel_size = getattr(self, f'voxel_size_{i}')
+                if voxel_size:
+                    deformation_element.voxel_size = voxel_size
+                bounding_box = getattr(self, f'bounding_box_{i}')
+                if bounding_box:
+                    deformation_element.bounding_box = numpy.array(bounding_box)
+
+            elif deformation_type == 'imported_mat':
+                deformation_element = composition.MatFileImported()
+                deformation_element.parameter_file_path = getattr(self, f'param_file_{i}').fullPath()
+                voxel_size = getattr(self, f'voxel_size_{i}')
+                if voxel_size:
+                    deformation_element.voxel_size = voxel_size
+                bounding_box = getattr(self, f'bounding_box_{i}')
+                if bounding_box:
+                    deformation_element.bounding_box = numpy.array(bounding_box)
         
-        deformations.appendDeformation(deformation_element)
+            deformations.appendDeformation(deformation_element)
     
-    save_deformation = SaveDeformation()
+        save_deformation = SaveDeformation()
     
-    deformation_tmp = context.temporary('NIFTI-1 image')
-    deformation_name = os.path.basename(deformation_tmp.fullPath())
-    output_dir = os.path.dirname(deformation_tmp.fullPath())
+        deformation_tmp = context.temporary('NIFTI-1 image')
+        deformation_name = os.path.basename(deformation_tmp.fullPath())
+        output_dir = os.path.dirname(deformation_tmp.fullPath())
     
-    save_deformation.setDeformationName(deformation_name)
-    save_deformation.setOutputDestinationToOutputDirectory(output_dir)
-    save_deformation.setOutputDeformationPath(self.output_deformation.fullPath())
+        save_deformation.setDeformationName(deformation_name)
+        save_deformation.setOutputDestinationToOutputDirectory(output_dir)
+        save_deformation.setOutputDeformationPath(self.output_deformation.fullPath())
 
-    deformations.appendOutput(save_deformation)
+        deformations.appendOutput(save_deformation)
 
-    spm = validation()
-    spm.addModuleToExecutionQueue(deformations)
-    spm.setSPMScriptPath(self.batch_location.fullPath())
-    output = spm.run()
-    context.log(name, html=output)
+        spm = validation()
+        spm.addModuleToExecutionQueue(deformations)
+        spm.setSPMScriptPath(self.batch_location.fullPath())
+        output = spm.run()
+        context.log(name, html=output)
+
+    finally:
+        shutil.rmtree(temp_directory.fullPath())

--- a/brainvisa/toolboxes/spm/processes/spm12/util/SPM12composition_generic.py
+++ b/brainvisa/toolboxes/spm/processes/spm12/util/SPM12composition_generic.py
@@ -97,7 +97,7 @@ def identity_params(num):
 
 def imported_mat_params(num):
     return {
-        f'param_file_{num}': ReadDiskItem('Any Type', getAllFormats(),
+        f'param_file_{num}': ReadDiskItem('Any Type', 'Matlab file',
                                           section=deformations.format(num)),
         f'voxel_size_{num}': ListOf(Float(),
                                     section=deformations.format(num)),

--- a/brainvisa/toolboxes/spm/processes/spm12/util/SPM12composition_generic.py
+++ b/brainvisa/toolboxes/spm/processes/spm12/util/SPM12composition_generic.py
@@ -203,7 +203,7 @@ def execution(self, context):
             if deformation_file.endswith('.gz'):
                 src_gz = shutil.copy(deformation_file, temp_directory.fullPath())
                 context.system('gunzip', src_gz)
-                source = '.'.join(src_gz.split('.')[:-1])
+                source = src_gz[:-3]
             else:
                 source = deformation_file
             deformation_element.deformation_field_path = source

--- a/python/soma/spm/spm12/util/deformations/output.py
+++ b/python/soma/spm/spm12/util/deformations/output.py
@@ -71,8 +71,10 @@ class SaveDeformation(Output):
     def _moveSPMDefaultPathsIfNeeded(self):
         if self.deformation_saved_path is not None:
             ouput_directory = self.output_destination.getOutputDirectory()
-            spm_default_output_path = os.path.join(
-                ouput_directory, 'y_'+self.deformation_name)
+            spm_default_output_path = os.path.join(ouput_directory, 'y_' + self.deformation_name)
+            if not spm_default_output_path.endswith('.nii'):
+                spm_default_output_path += '.nii'
+            
             moveFileAndCreateFoldersIfNeeded(
                 spm_default_output_path, self.deformation_saved_path)
         else:


### PR DESCRIPTION
This branch fixes issues with SPM12 deformation composition process. The issue was when using `.nii.gz` files as deformation fields. They were correctly unzipped in temporary files as brainvisa used to do, with a name like `bv_something.nii`.
But in this case, deformation fields need to start with `y_` to be valid for SPM.
I did not find an option to specify a prefix during the automatic unzip of Brainvisa. I then tried to manage this directly in execution.

I encountered a problem about the use of `context.temporary()`. I need to remove manually directory at the end of the process to delete it at the end of the process. If I did not, the directory stay in my tmp until Brainvisa is shutdown. But I though it will be more convenient to remove the directory at the end of the execution.
Maybe I missed an option or something about `context.temporary`