### PR TITLE
Coreg estimate on input

### DIFF
--- a/brainvisa/toolboxes/spm/processes/spm12/spatial/SPM12CoregisterEandR_generic.py
+++ b/brainvisa/toolboxes/spm/processes/spm12/spatial/SPM12CoregisterEandR_generic.py
@@ -94,6 +94,7 @@ def initialization(self):
     self.extract_coregister_matrix = False
 
     self.custom_outputs = False
+    self.deformation_in_source = True
 
 
 def updateSignatureAboutCustomOutputs(self, proc):

--- a/brainvisa/toolboxes/spm/processes/spm12/spatial/SPM12CoregisterEandR_generic.py
+++ b/brainvisa/toolboxes/spm/processes/spm12/spatial/SPM12CoregisterEandR_generic.py
@@ -1,36 +1,6 @@
-# -*- coding: utf-8 -*-
-#  This software and supporting documentation are distributed by
-#      Institut Federatif de Recherche 49
-#      CEA/NeuroSpin, Batiment 145,
-#      91191 Gif-sur-Yvette cedex
-#      France
-#
-# This software is governed by the CeCILL license version 2 under
-# French law and abiding by the rules of distribution of free software.
-# You can  use, modify and/or redistribute the software under the
-# terms of the CeCILL license version 2 as circulated by CEA, CNRS
-# and INRIA at the following URL "http://www.cecill.info".
-#
-# As a counterpart to the access to the source code and  rights to copy,
-# modify and redistribute granted by the license, users are provided only
-# with a limited warranty  and the software's author,  the holder of the
-# economic rights,  and the successive licensors  have only  limited
-# liability.
-#
-# In this respect, the user's attention is drawn to the risks associated
-# with loading,  using,  modifying and/or developing or reproducing the
-# software by the user in light of its specific status of free software,
-# that may mean  that it is complicated to manipulate,  and  that  also
-# therefore means  that it is reserved for developers  and  experienced
-# professionals having in-depth computer knowledge. Users are therefore
-# encouraged to load and test the software's suitability as regards their
-# requirements in conditions enabling the security of their systems and/or
-# data to be ensured and,  more generally, to use and operate it in the
-# same conditions as regards security.
-#
-# The fact that you are presently reading this means that you have had
-# knowledge of the CeCILL license version 2 and that you accept its terms.
-from __future__ import absolute_import
+import os.path as osp
+import shutil
+
 from brainvisa.processes import *
 from soma.spm.spm12.spatial.coregister.reslice_options import ResliceOptions
 from soma.spm.spm12.spatial.coregister.estimation_options import EstimationOptions
@@ -158,7 +128,12 @@ def updateBatchPath(self, proc):
 
 
 def execution(self, context):
-    source_diskitem = self.source
+    if not self.source.isTemporary():
+        source_diskitem = context.temporary(self.source.format)
+        shutil.copy2(self.source.fullPath(),
+                     source_diskitem.fullPath())
+    else:
+        source_diskitem = self.source
     reference_diskitem = self.reference
 
     if self.others and self.custom_outputs:

--- a/brainvisa/toolboxes/spm/processes/spm12/spatial/SPM12CoregisterEandR_generic.py
+++ b/brainvisa/toolboxes/spm/processes/spm12/spatial/SPM12CoregisterEandR_generic.py
@@ -1,4 +1,3 @@
-import os.path as osp
 import shutil
 
 from brainvisa.processes import *

--- a/brainvisa/toolboxes/spm/processes/spm12/spatial/SPM12CoregisterEandR_generic.py
+++ b/brainvisa/toolboxes/spm/processes/spm12/spatial/SPM12CoregisterEandR_generic.py
@@ -66,6 +66,7 @@ signature = Signature(
     "filename_prefix", String(),
     "extract_coregister_matrix", Boolean(),
     "coregister_matrix", WriteDiskItem("Transformation matrix", "Transformation matrix"),
+    "deformation_in_source", Boolean(),
 
     'batch_location', WriteDiskItem('Matlab SPM script', 'Matlab script', section='default SPM outputs'),
 )
@@ -128,12 +129,12 @@ def updateBatchPath(self, proc):
 
 
 def execution(self, context):
-    if not self.source.isTemporary():
+    if self.deformation_in_source:
+        source_diskitem = self.source
+    else:
         source_diskitem = context.temporary(self.source.format)
         shutil.copy2(self.source.fullPath(),
                      source_diskitem.fullPath())
-    else:
-        source_diskitem = self.source
     reference_diskitem = self.reference
 
     if self.others and self.custom_outputs:


### PR DESCRIPTION
By default, SPM Coregister saves the deformation estimation in the header of the **source** input. Sometimes we do not want this behavior in our pipeline, so I wanted to add something to avoid it. For now the behavior is not the same if we use nifti or compressed nifti as **source**.
We need to be sure of what the process can do:
- never save deformation in header of the source
- keep SPM behavior by default: 
  - with an option for the user to avoid it explicitly
  - avoid it in case of "custom_outputs" selected

What do you think @clarafischer? I tried to implement first and second option in this branch.